### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Clok
 [![https://badge.fury.io/py/clok](https://badge.fury.io/py/clok.png)](https://badge.fury.io/py/clok)
 [![Build Status](https://travis-ci.org/fspot/clok.svg)](https://travis-ci.org/fspot/clok)
 [![Coverage Status](https://coveralls.io/repos/fspot/clok/badge.png)](https://coveralls.io/r/fspot/clok)
-[![License](https://pypip.in/license/clok/badge.svg)](https://pypi.python.org/pypi/clok/)
+[![License](https://img.shields.io/pypi/l/clok.svg)](https://pypi.python.org/pypi/clok/)
 
 Listen to radio and set up alarms from your computer, and control it from a web UI. Relies on `mplayer`.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20clok))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `clok`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.